### PR TITLE
Enable conversion from python list to scala.collection.immutable.List

### DIFF
--- a/sagemaker-pyspark-sdk/src/sagemaker_pyspark/wrapper.py
+++ b/sagemaker-pyspark-sdk/src/sagemaker_pyspark/wrapper.py
@@ -174,8 +174,7 @@ class ScalaList(SageMakerJavaWrapper):
         # Since py4j cannot deal with scala list directly
         # we convert to scala listmap as an intermediate step
         s_list = self._new_java_obj("scala.collection.immutable.ListMap")
-        key_list = range(len(self.p_list))
-        for elem, key in zip(self.p_list, key_list):
+        for key, elem in enumerate(self.p_list):
             tuple = self._new_java_obj("scala.Tuple2", key, elem)
             s_list = getattr(s_list, "$plus")(tuple)
         s_list = s_list.values().toList()

--- a/sagemaker-pyspark-sdk/src/sagemaker_pyspark/wrapper.py
+++ b/sagemaker-pyspark-sdk/src/sagemaker_pyspark/wrapper.py
@@ -142,6 +142,7 @@ class Option(SageMakerJavaWrapper):
 
 
 class ScalaMap(SageMakerJavaWrapper):
+
     _wrapped_class = "scala.collection.immutable.HashMap"
 
     def __init__(self, dictionary):
@@ -164,6 +165,8 @@ class ScalaMap(SageMakerJavaWrapper):
 # wrap scala.collection.immutable.List
 class ScalaList(SageMakerJavaWrapper):
 
+    _wrapped_class = "scala.collection.immutable.List"
+
     def __init__(self, p_list):
         self.p_list = p_list
 
@@ -171,13 +174,11 @@ class ScalaList(SageMakerJavaWrapper):
         # Since py4j cannot deal with scala list directly
         # we convert to scala listmap as an intermediate step
         s_list = self._new_java_obj("scala.collection.immutable.ListMap")
-        key = 0
-        for elem in self.p_list:
+        key_list = range(len(self.p_list))
+        for elem, key in zip(self.p_list, key_list):
             tuple = self._new_java_obj("scala.Tuple2", key, elem)
             s_list = getattr(s_list, "$plus")(tuple)
-            key += 1
-        s_list = getattr(s_list, "values")()
-        s_list = getattr(s_list, "toList")()
+        s_list = s_list.values().toList()
 
         return s_list
 

--- a/sagemaker-pyspark-sdk/tests/wrapper_test.py
+++ b/sagemaker-pyspark-sdk/tests/wrapper_test.py
@@ -1,0 +1,38 @@
+import os
+import pytest
+
+from pyspark import SparkConf, SparkContext
+
+from sagemaker_pyspark import (S3DataPath, EndpointCreationPolicy, RandomNamePolicyFactory,
+                               SageMakerClients, IAMRole, classpath_jars)
+from sagemaker_pyspark.wrapper import ScalaMap, ScalaList
+
+
+@pytest.fixture(autouse=True)
+def with_spark_context():
+    os.environ['SPARK_CLASSPATH'] = ":".join(classpath_jars())
+    conf = (SparkConf()
+            .set("spark.driver.extraClassPath", os.environ['SPARK_CLASSPATH']))
+
+    if SparkContext._active_spark_context is None:
+        SparkContext(conf=conf)
+
+    yield SparkContext._active_spark_context
+
+    # TearDown
+    SparkContext.stop(SparkContext._active_spark_context)
+
+
+def test_convert_dictionary():
+    dictionary = {"key": "value"}
+    map = ScalaMap(dictionary)._to_java()
+    assert getattr(map, "apply")("key") == "value"
+
+
+def test_convert_list():
+    list = ["features", "label", "else"]
+
+    s_list = ScalaList(list)._to_java()
+    assert getattr(s_list, "apply")(0) == "features"
+    assert getattr(s_list, "apply")(1) == "label"
+    assert getattr(s_list, "apply")(2) == "else"

--- a/sagemaker-pyspark-sdk/tests/wrapper_test.py
+++ b/sagemaker-pyspark-sdk/tests/wrapper_test.py
@@ -5,7 +5,7 @@ from pyspark import SparkConf, SparkContext
 
 from sagemaker_pyspark import (S3DataPath, EndpointCreationPolicy, RandomNamePolicyFactory,
                                SageMakerClients, IAMRole, classpath_jars)
-from sagemaker_pyspark.wrapper import ScalaMap, ScalaList
+from sagemaker_pyspark.wrapper import Option, ScalaMap, ScalaList
 
 
 @pytest.fixture(autouse=True)
@@ -31,8 +31,13 @@ def test_convert_dictionary():
 
 def test_convert_list():
     list = ["features", "label", "else"]
-
     s_list = ScalaList(list)._to_java()
     assert getattr(s_list, "apply")(0) == "features"
     assert getattr(s_list, "apply")(1) == "label"
     assert getattr(s_list, "apply")(2) == "else"
+
+
+def test_convert_option():
+    list = ["features", "label", "else"]
+    option = Option(list)._to_java()
+    assert getattr(getattr(option, "get")(), "apply")(0) == "features"

--- a/sagemaker-pyspark-sdk/tests/wrapper_test.py
+++ b/sagemaker-pyspark-sdk/tests/wrapper_test.py
@@ -3,8 +3,7 @@ import pytest
 
 from pyspark import SparkConf, SparkContext
 
-from sagemaker_pyspark import (S3DataPath, EndpointCreationPolicy, RandomNamePolicyFactory,
-                               SageMakerClients, IAMRole, classpath_jars)
+from sagemaker_pyspark import classpath_jars
 from sagemaker_pyspark.wrapper import Option, ScalaMap, ScalaList
 
 
@@ -26,18 +25,21 @@ def with_spark_context():
 def test_convert_dictionary():
     dictionary = {"key": "value"}
     map = ScalaMap(dictionary)._to_java()
-    assert getattr(map, "apply")("key") == "value"
+
+    assert map.apply("key") == "value"
 
 
 def test_convert_list():
     list = ["features", "label", "else"]
     s_list = ScalaList(list)._to_java()
-    assert getattr(s_list, "apply")(0) == "features"
-    assert getattr(s_list, "apply")(1) == "label"
-    assert getattr(s_list, "apply")(2) == "else"
+
+    assert s_list.apply(0) == "features"
+    assert s_list.apply(1) == "label"
+    assert s_list.apply(2) == "else"
 
 
 def test_convert_option():
     list = ["features", "label", "else"]
     option = Option(list)._to_java()
-    assert getattr(getattr(option, "get")(), "apply")(0) == "features"
+
+    assert option.get().apply(0) == "features"


### PR DESCRIPTION
Description:

1, Enable conversion from python list to scala.collection.immutable.List
Since py4j cannot make this conversion directly. I convert python list to scala.collection.immutable.ListMap first with all list elements to be values in ListMap. Then I convert this ListMap to scala.collection.immutable.List by getting all values from ListMap.
The reason to use ListMap as an intermediate step is, we want to keep the insertion order.
The reason to put all list elements as values instead of keys in ListMap is, we want to keep duplicates elements.

2, Add unit tests to test pyspark wrapper, including map conversion test, list conversion test and option conversion test.

This should fix https://github.com/aws/sagemaker-spark/issues/12