### PR TITLE
Add module pytest-xdist to enable parallel testing

### DIFF
--- a/sagemaker-pyspark-sdk/setup.py
+++ b/sagemaker-pyspark-sdk/setup.py
@@ -92,7 +92,7 @@ try:  # noqa
         ],
 
         setup_requires=["pyspark", "pypandoc", "pytest-runner", "numpy"],
-        tests_require=["pytest", "pytest-cov", "coverage", "teamcity-messages"]
+        tests_require=["pytest", "pytest-cov", "pytest-xdist", "coverage", "teamcity-messages"]
 
     )
 


### PR DESCRIPTION
Add module pytest-xdist to enable parallel testing

This will be applied to integ tests, not unit tests