### PR TITLE
Ignore exit code of coverage stats report to pass integ tests

### DIFF
--- a/sagemaker-pyspark-sdk/tox.ini
+++ b/sagemaker-pyspark-sdk/tox.ini
@@ -46,8 +46,8 @@ passenv = TEAMCITY_VERSION
 basepython=python3
 skip_install=true
 commands=
-  coverage report
-  coverage html
+  - coverage report
+  - coverage html
 
 [testenv:clean]
 basepython=python3


### PR DESCRIPTION
Add "-" before coverage report related commands in tox.ini

According to official doc of tox, this will ignore the exit code of the commands. So even these coverage report related commands failed due to no data to report from integ tests. The entire build will not fail.