### PR TITLE
Fix XGBoostEstimator maxDepth parameter from Double to Int

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 CHANGELOG
 =========
 
+1.0.3
+=====
+
+* feature: XGBoostSageMakerEstimator: Fix maxDepth hyperparameter to use correct type (Int)
+
+
 1.0.2
 =====
 

--- a/sagemaker-pyspark-sdk/setup.py
+++ b/sagemaker-pyspark-sdk/setup.py
@@ -7,7 +7,7 @@ import sys
 from setuptools import setup
 
 
-VERSION = "1.0.2"
+VERSION = "1.0.3"
 
 TEMP_PATH = "deps"
 JARS_TARGET = os.path.join(TEMP_PATH, "jars")

--- a/sagemaker-pyspark-sdk/src/sagemaker_pyspark/algorithms/XGBoostSageMakerEstimator.py
+++ b/sagemaker-pyspark-sdk/src/sagemaker_pyspark/algorithms/XGBoostSageMakerEstimator.py
@@ -137,7 +137,7 @@ class XGBoostSageMakerEstimator(SageMakerEstimatorBase):
         Params._dummy(), "max_depth",
         "Minimum loss reduction required to make a further partition on a leaf node of the tree. "
         "The larger the value, the more conservative the algorithm will be. Must be >= 0",
-        typeConverter=TypeConverters.toFloat)
+        typeConverter=TypeConverters.toInt)
 
     min_child_weight = Param(
         Params._dummy(), "min_child_weight",

--- a/sagemaker-pyspark-sdk/tests/algorithms/xgboost_sagemakerestimator_test.py
+++ b/sagemaker-pyspark-sdk/tests/algorithms/xgboost_sagemakerestimator_test.py
@@ -200,8 +200,8 @@ def test_xgboostSageMakerEstimator_validates_gamma():
 def test_xgboostSageMakerEstimator_validates_maxDepth():
     estimator = get_xgboost_estimator()
 
-    estimator.setMaxDepth(1.1)
-    assert estimator.getMaxDepth() == 1.1
+    estimator.setMaxDepth(1)
+    assert estimator.getMaxDepth() == 1
 
     with pytest.raises(ValueError):
         estimator.setMaxDepth(-1)

--- a/sagemaker-spark-sdk/build.sbt
+++ b/sagemaker-spark-sdk/build.sbt
@@ -19,7 +19,7 @@ scalaVersion := "2.11.7"
 // to change the version of spark add -DSPARK_VERSION=2.x.x when running sbt
 // for example: "sbt -DSPARK_VERSION=2.1.1 clean compile test doc package"
 val sparkVersion = System.getProperty("SPARK_VERSION", "2.2.0")
-version := "spark_" + sparkVersion + "-1.0.2"
+version := "spark_" + sparkVersion + "-1.0.3"
 
 lazy val SageMakerSpark = (project in file("."))
 

--- a/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimator.scala
+++ b/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimator.scala
@@ -91,12 +91,12 @@ private[algorithms] trait XGBoostParams extends Params {
     * Must be >= 0.
     * Default = 6
     */
-  val maxDepth: DoubleParam = new DoubleParam(this, "max_depth",
+  val maxDepth: IntParam = new IntParam(this, "max_depth",
     " Maximum depth of a tree, increase this value will make the model more complex (likely to be" +
       " overfitting). 0 indicates no limit, limit is required when grow_policy=depth-wise. " +
       "Must be >= 0. ",
     ParamValidators.gtEq(0))
-  def getMaxDepth: Double = $(maxDepth)
+  def getMaxDepth: Int = $(maxDepth)
 
   /** Minimum sum of instance weight (hessian) needed in a child. If the tree partition step results
     * in a leaf node with the sum of instance weight less than min_child_weight, then the building
@@ -558,7 +558,7 @@ class XGBoostSageMakerEstimator(
 
   def setGamma(value: Double) : this.type = set(gamma, value)
 
-  def setMaxDepth(value: Double) : this.type = set(maxDepth, value)
+  def setMaxDepth(value: Int) : this.type = set(maxDepth, value)
 
   def setMinChildWeight(value: Double) : this.type = set(minChildWeight, value)
 

--- a/sagemaker-spark-sdk/src/test/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimatorTests.scala
+++ b/sagemaker-spark-sdk/src/test/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimatorTests.scala
@@ -105,7 +105,7 @@ class XGBoostSageMakerEstimatorTests extends FlatSpec with Matchers with Mockito
 
 
   it should "setMaxDepth" in {
-    val maxDepth = 10.0
+    val maxDepth = 10
     estimator.setMaxDepth(maxDepth)
     assert(maxDepth == estimator.getMaxDepth)
   }
@@ -354,7 +354,7 @@ class XGBoostSageMakerEstimatorTests extends FlatSpec with Matchers with Mockito
       "nthread" -> "2",
       "eta" -> "0.3",
       "gamma" -> "0.1",
-      "max_depth" -> "8.0",
+      "max_depth" -> "8",
       "min_child_weight" -> "0.8",
       "max_delta_step" -> "0.8",
       "subsample" -> "0.8",
@@ -418,7 +418,7 @@ class XGBoostSageMakerEstimatorTests extends FlatSpec with Matchers with Mockito
 
   it should "validate maxDepth" in {
     val maxDepth = intercept[IllegalArgumentException] {
-      estimator.setMaxDepth(-1.0)
+      estimator.setMaxDepth(-1)
     }
   }
 


### PR DESCRIPTION
MaxDepth should be an int: https://docs.aws.amazon.com/sagemaker/latest/dg/xgboost_hyperparameters.html

The algorithm container now validates this and only accepts ints.

Testing done:
"sbt test" passes