### PR TITLE
Fix seed parameter for XGBoost

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ CHANGELOG
 ========
 
 * pyspark: SageMakerModel: Fix bugs in creating model from training job, s3 file and endpoint
-* spark: XGBoostSageMakerEstimator: Fix seed hyperparameter to use correct type (Int)
+* spark/pyspark: XGBoostSageMakerEstimator: Fix seed hyperparameter to use correct type (Int)
 
 1.0.4
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ CHANGELOG
 ========
 
 * pyspark: SageMakerModel: Fix bugs in creating model from training job, s3 file and endpoint
-
+* spark: XGBoostSageMakerEstimator: Fix seed hyperparameter to use correct type (Int)
 
 1.0.4
 =====

--- a/sagemaker-pyspark-sdk/src/sagemaker_pyspark/algorithms/XGBoostSageMakerEstimator.py
+++ b/sagemaker-pyspark-sdk/src/sagemaker_pyspark/algorithms/XGBoostSageMakerEstimator.py
@@ -331,7 +331,7 @@ class XGBoostSageMakerEstimator(SageMakerEstimatorBase):
     seed = Param(
         Params._dummy(), "seed",
         "Random number seed",
-        typeConverter=TypeConverters.toFloat)
+        typeConverter=TypeConverters.toInt)
 
     num_round = Param(
         Params._dummy(), "num_round",

--- a/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimator.scala
+++ b/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimator.scala
@@ -379,8 +379,8 @@ private[algorithms] trait XGBoostParams extends Params {
   /** Random number seed.
     * Default = 0
     */
-  val seed: DoubleParam = new DoubleParam(this, "seed", "Random number seed.")
-  def getSeed: Double = $(seed)
+  val seed: IntParam = new IntParam(this, "seed", "Random number seed.")
+  def getSeed: Int = $(seed)
 
   /**
     * Number of rounds for gradient boosting. Must be >= 1. Required.
@@ -614,7 +614,7 @@ class XGBoostSageMakerEstimator(
 
   def setEvalMetric(value: String) : this.type = set(evalMetric, value)
 
-  def setSeed(value: Double) : this.type = set(seed, value)
+  def setSeed(value: Int) : this.type = set(seed, value)
 
   def setNumRound(value: Int) : this.type = set(numRound, value)
 

--- a/sagemaker-spark-sdk/src/test/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimatorTests.scala
+++ b/sagemaker-spark-sdk/src/test/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimatorTests.scala
@@ -301,7 +301,7 @@ class XGBoostSageMakerEstimatorTests extends FlatSpec with Matchers with Mockito
 
 
   it should "setSeed" in {
-    val seed = 10.0
+    val seed = 10
     estimator.setSeed(seed)
     assert(seed == estimator.getSeed)
   }
@@ -381,7 +381,7 @@ class XGBoostSageMakerEstimatorTests extends FlatSpec with Matchers with Mockito
       "objective" -> "reg:logistic",
       "base_score" -> "0.5",
       "eval_metric" -> "mae",
-      "seed" -> "0.0"
+      "seed" -> "0"
     )
 
     assert(hyperParamMap.asJava == estimator.makeHyperParameters())


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-spark/issues/40

*Description of changes:*
Change type of seed parameter from double to int.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-spark/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have updated the [changelog](https://github.com/aws/sagemaker-spark/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [x] I have updated any necessary [documentation](https://github.com/aws/sagemaker-spark/blob/master/README.md) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
