### PR TITLE
change xgboost to default to unlabeled libsvm serializer

### DIFF
--- a/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimator.scala
+++ b/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimator.scala
@@ -30,7 +30,7 @@ import com.amazonaws.services.sagemaker.sparksdk._
 import com.amazonaws.services.sagemaker.sparksdk.EndpointCreationPolicy.EndpointCreationPolicy
 import com.amazonaws.services.sagemaker.sparksdk.transformation.{RequestRowSerializer, ResponseRowDeserializer}
 import com.amazonaws.services.sagemaker.sparksdk.transformation.deserializers.XGBoostCSVRowDeserializer
-import com.amazonaws.services.sagemaker.sparksdk.transformation.serializers.LibSVMRequestRowSerializer
+import com.amazonaws.services.sagemaker.sparksdk.transformation.serializers.UnlabeledLibSVMRequestRowSerializer
 
 private[algorithms] trait XGBoostParams extends Params {
 
@@ -477,7 +477,7 @@ class XGBoostSageMakerEstimator(
            override val endpointInstanceType : String,
            override val endpointInitialInstanceCount : Int,
            override val requestRowSerializer : RequestRowSerializer =
-             new LibSVMRequestRowSerializer(),
+             new UnlabeledLibSVMRequestRowSerializer(),
            override val responseRowDeserializer : ResponseRowDeserializer =
              new XGBoostCSVRowDeserializer(),
            override val trainingInputS3DataPath : S3Resource = S3AutoCreatePath(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current serializer expects a column of labels, which isn't needed.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-spark/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-spark/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-spark/blob/master/README.md) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
