### PR TITLE
Increase read timeout for sagemaker runtime

### DIFF
--- a/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/transformation/util/RequestBatchIterator.scala
+++ b/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/transformation/util/RequestBatchIterator.scala
@@ -24,9 +24,11 @@ import com.amazonaws.ClientConfiguration
 import com.amazonaws.services.sagemakerruntime.{AmazonSageMakerRuntime, AmazonSageMakerRuntimeClientBuilder}
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointRequest
 import com.amazonaws.util.BinaryUtils
+
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types.StructType
+
 import com.amazonaws.services.sagemaker.sparksdk.transformation.{RequestRowSerializer, ResponseRowDeserializer}
 
 object RequestBatchIterator {

--- a/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/transformation/util/RequestBatchIterator.scala
+++ b/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/transformation/util/RequestBatchIterator.scala
@@ -20,19 +20,21 @@ import java.nio.ByteBuffer
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
+import com.amazonaws.ClientConfiguration
 import com.amazonaws.services.sagemakerruntime.{AmazonSageMakerRuntime, AmazonSageMakerRuntimeClientBuilder}
 import com.amazonaws.services.sagemakerruntime.model.InvokeEndpointRequest
 import com.amazonaws.util.BinaryUtils
-
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types.StructType
-
 import com.amazonaws.services.sagemaker.sparksdk.transformation.{RequestRowSerializer, ResponseRowDeserializer}
 
 object RequestBatchIterator {
   var sagemakerRuntime : AmazonSageMakerRuntime =
-    AmazonSageMakerRuntimeClientBuilder.defaultClient
+    AmazonSageMakerRuntimeClientBuilder
+      .standard()
+      .withClientConfiguration(new ClientConfiguration().withSocketTimeout(80 * 1000))
+      .build()
 }
 
 /**


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-spark/issues/64
The error response for an inference taking more than 60 seconds is supposed to be returned by the hosting service, however the default timeout is 50 seconds. https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/constant-values.html#com.amazonaws.ClientConfiguration.DEFAULT_SOCKET_TIMEOUT

Thus, the error from the hosting service isn't able to be propagated to the customer before the default timeout error happens.

Same change for Python SDK.
https://github.com/aws/sagemaker-python-sdk/pull/355

*Description of changes:*
Increase read timeout for SageMaker runtime, as the hosting endpoint has a time limit on how long an inference can take.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
