### PR TITLE
custom configuration for SageMaker entities

### DIFF
--- a/sagemaker-pyspark-sdk/src/sagemaker_pyspark/NamePolicy.py
+++ b/sagemaker-pyspark-sdk/src/sagemaker_pyspark/NamePolicy.py
@@ -47,6 +47,68 @@ class RandomNamePolicy(NamePolicy):
         pass
 
 
+class CustomNamePolicy(NamePolicy):
+    """
+    Provides custom SageMaker entity names.
+
+    Args:
+        trainingJobName (str): The name of the SageMaker entity
+        modelName (str): The model name of the SageMaker entity
+        endpointConfigName (str): The endpoint config name of the SageMaker entity
+        endpointName (str): The endpoint name of the SageMaker entity
+    """
+
+    _wrapped_class = "com.amazonaws.services.sagemaker.sparksdk.CustomNamePolicy"
+
+    def __init__(self, trainingJobName, modelName, endpointConfigName, endpointName):
+        self.trainingJobName = trainingJobName
+        self.modelName = modelName
+        self.endpointConfigName = endpointConfigName
+        self.endpointName = endpointName
+        self._java_obj = None
+
+    def _to_java(self):
+        if self._java_obj is None:
+            self._java_obj = self._new_java_obj(CustomNamePolicy._wrapped_class,
+                                                self.trainingJobName, self.modelName,
+                                                self.endpointConfigName, self.endpointName)
+        return self._java_obj
+
+    def _from_java(cls, JavaObject):
+        pass
+
+
+class CustomNamePolicyWithTimeStampSuffix(NamePolicy):
+    """
+    Provides custom SageMaker entity names with timestamp suffix.
+
+    Args:
+        trainingJobName (str): The job name of the SageMaker entity
+        modelName (str): The model name of the SageMaker entity
+        endpointConfigName (str): The endpoint config name of the SageMaker entity
+        endpointName (str): The endpoint name of the SageMaker entity
+    """
+
+    _wrapped_class = "com.amazonaws.services.sagemaker.sparksdk.CustomNamePolicyWithTimeStampSuffix"
+
+    def __init__(self, trainingJobName, modelName, endpointConfigName, endpointName):
+        self.trainingJobName = trainingJobName
+        self.modelName = modelName
+        self.endpointConfigName = endpointConfigName
+        self.endpointName = endpointName
+        self._java_obj = None
+
+    def _to_java(self):
+        if self._java_obj is None:
+            self._java_obj = self._new_java_obj(CustomNamePolicyWithTimeStampSuffix._wrapped_class,
+                                                self.trainingJobName, self.modelName,
+                                                self.endpointConfigName, self.endpointName)
+        return self._java_obj
+
+    def _from_java(cls, JavaObject):
+        pass
+
+
 class NamePolicyFactory(SageMakerJavaWrapper):
     """
     Creates a NamePolicy upon a call to createNamePolicy
@@ -84,3 +146,75 @@ class RandomNamePolicyFactory(NamePolicyFactory):
 
     def createNamePolicy(self):
         return self._call_java("createNamePolicy", self.prefix)
+
+
+class CustomNamePolicyFactory(NamePolicyFactory):
+    """
+    Creates a CustomNamePolicy upon a call to createNamePolicy
+
+    Args:
+        trainingJobName (str): The job name of the SageMaker entity with this NamePolicy.
+        modelName (str): The job name of the SageMaker entity with this NamePolicy.
+        endpointConfigName (str): The job name of the SageMaker entity with this NamePolicy.
+        endpointName (str): The job name of the SageMaker entity with this NamePolicy.
+    """
+
+    _wrapped_class = "com.amazonaws.services.sagemaker.sparksdk.CustomNamePolicyFactory"
+
+    def __init__(self, trainingJobName, modelName, endpointConfigName, endpointName):
+        self.trainingJobName = trainingJobName
+        self.modelName = modelName
+        self.endpointConfigName = endpointConfigName
+        self.endpointName = endpointName
+        self._java_obj = None
+
+    def _to_java(self):
+        if self._java_obj is None:
+            self._java_obj = self._new_java_obj(CustomNamePolicyFactory._wrapped_class,
+                                                self.trainingJobName, self.modelName,
+                                                self.endpointConfigName, self.endpointName)
+        return self._java_obj
+
+    def _from_java(cls, JavaObject):
+        pass
+
+    def createNamePolicy(self):
+        return self._call_java("createNamePolicy", self.trainingJobName,
+                               self.modelName, self.endpointConfigName, self.endpointName)
+
+
+class CustomNamePolicyWithTimeStampSuffixFactory(NamePolicyFactory):
+    """
+    Creates a CustomNamePolicyFactoryWithTimeStampSuffix upon a call to createNamePolicy
+
+    Args:
+        trainingJobName (str): The job name of the SageMaker entity with this NamePolicy.
+        modelName (str): The job name of the SageMaker entity with this NamePolicy.
+        endpointConfigName (str): The job name of the SageMaker entity with this NamePolicy.
+        endpointName (str): The job name of the SageMaker entity with this NamePolicy.
+    """
+
+    _wrapped_class = \
+        "com.amazonaws.services.sagemaker.sparksdk.CustomNamePolicyWithTimeStampSuffixFactory"
+
+    def __init__(self, trainingJobName, modelName, endpointConfigName, endpointName):
+        self.trainingJobName = trainingJobName
+        self.modelName = modelName
+        self.endpointConfigName = endpointConfigName
+        self.endpointName = endpointName
+        self._java_obj = None
+
+    def _to_java(self):
+        if self._java_obj is None:
+            self._java_obj = self._new_java_obj(
+                CustomNamePolicyWithTimeStampSuffixFactory._wrapped_class,
+                self.trainingJobName, self.modelName,
+                self.endpointConfigName, self.endpointName)
+        return self._java_obj
+
+    def _from_java(cls, JavaObject):
+        pass
+
+    def createNamePolicy(self):
+        return self._call_java("createNamePolicy", self.trainingJobName,
+                               self.modelName, self.endpointConfigName, self.endpointName)

--- a/sagemaker-pyspark-sdk/src/sagemaker_pyspark/__init__.py
+++ b/sagemaker-pyspark-sdk/src/sagemaker_pyspark/__init__.py
@@ -20,7 +20,11 @@ from .wrapper import SageMakerJavaWrapper, Option
 from .IAMRoleResource import IAMRole, IAMRoleFromConfig
 from .SageMakerClients import SageMakerClients
 from .S3Resources import S3DataPath, S3Resource, S3AutoCreatePath
-from .NamePolicy import RandomNamePolicy, RandomNamePolicyFactory
+from .NamePolicy import RandomNamePolicy, RandomNamePolicyFactory, \
+                        CustomNamePolicy, CustomNamePolicyFactory, \
+                        CustomNamePolicyWithTimeStampSuffix, \
+                        CustomNamePolicyWithTimeStampSuffixFactory
+
 from .SageMakerEstimator import EndpointCreationPolicy, SageMakerEstimator, SageMakerEstimatorBase
 from .SageMakerModel import SageMakerModel
 from .SageMakerResourceCleanup import SageMakerResourceCleanup, CreatedResources
@@ -60,6 +64,10 @@ __all__ = ['SageMakerJavaWrapper',
            'Option',
            'RandomNamePolicy',
            'RandomNamePolicyFactory',
+           'CustomNamePolicy',
+           'CustomNamePolicyFactory',
+           'CustomNamePolicyWithTimeStampSuffix',
+           'CustomNamePolicyWithTimeStampSuffixFactory',
            'classpath_jars',
            'SageMakerResourceCleanup',
            'CreatedResources',

--- a/sagemaker-pyspark-sdk/tests/namepolicy_test.py
+++ b/sagemaker-pyspark-sdk/tests/namepolicy_test.py
@@ -26,20 +26,42 @@ def with_spark_context():
 
 
 def test_CustomNamePolicyFactory():
-    java_obj = CustomNamePolicyFactory("jobName", "modelname", "epconfig", "ep")
-    assert(isinstance(java_obj._to_java(), JavaObject))
+    policy_factory = CustomNamePolicyFactory("jobName", "modelname", "epconfig", "ep")
+    java_obj = policy_factory._to_java()
+    assert(isinstance(java_obj, JavaObject))
+    assert(java_obj.getClass().getSimpleName() == "CustomNamePolicyFactory")
+    policy_name = java_obj.createNamePolicy().getClass().getSimpleName()
+    assert(policy_name == "CustomNamePolicy")
 
 
 def test_CustomNamePolicyWithTimeStampSuffixFactory():
-    java_obj = CustomNamePolicyWithTimeStampSuffixFactory("jobName", "modelname", "epconfig", "ep")
-    assert(isinstance(java_obj._to_java(), JavaObject))
+    policy_factory = CustomNamePolicyWithTimeStampSuffixFactory("jobName", "modelname",
+                                                                "epconfig", "ep")
+    java_obj = policy_factory._to_java()
+    assert(isinstance(java_obj, JavaObject))
+    assert (java_obj.getClass().getSimpleName() == "CustomNamePolicyWithTimeStampSuffixFactory")
+    policy_name = java_obj.createNamePolicy().getClass().getSimpleName()
+    assert(policy_name == "CustomNamePolicyWithTimeStampSuffix")
 
 
 def test_CustomNamePolicyWithTimeStampSuffix():
-    java_obj = CustomNamePolicyWithTimeStampSuffix("jobName", "modelname", "epconfig", "ep")
-    assert(isinstance(java_obj._to_java(), JavaObject))
+    name_policy = CustomNamePolicyWithTimeStampSuffix("jobName", "modelname", "epconfig", "ep")
+    assert(isinstance(name_policy._to_java(), JavaObject))
+    assert(name_policy._call_java("trainingJobName") != "jobName")
+    assert(name_policy._call_java("modelName") != "modelname")
+    assert(name_policy._call_java("endpointConfigName") != "epconfig")
+    assert(name_policy._call_java("endpointName") != "ep")
+
+    assert (name_policy._call_java("trainingJobName").startswith("jobName"))
+    assert (name_policy._call_java("modelName").startswith("modelname"))
+    assert (name_policy._call_java("endpointConfigName").startswith("epconfig"))
+    assert (name_policy._call_java("endpointName").startswith("ep"))
 
 
 def test_CustomNamePolicy():
-    java_obj = CustomNamePolicy("jobName", "modelname", "epconfig", "ep")
-    assert (isinstance(java_obj._to_java(), JavaObject))
+    name_policy = CustomNamePolicy("jobName", "modelname", "epconfig", "ep")
+    assert (isinstance(name_policy._to_java(), JavaObject))
+    assert (name_policy._call_java("trainingJobName") == "jobName")
+    assert (name_policy._call_java("modelName") == "modelname")
+    assert (name_policy._call_java("endpointConfigName") == "epconfig")
+    assert (name_policy._call_java("endpointName") == "ep")

--- a/sagemaker-pyspark-sdk/tests/namepolicy_test.py
+++ b/sagemaker-pyspark-sdk/tests/namepolicy_test.py
@@ -1,0 +1,45 @@
+import pytest
+import os
+
+from sagemaker_pyspark import (CustomNamePolicyFactory, classpath_jars,
+                               CustomNamePolicyWithTimeStampSuffixFactory,
+                               CustomNamePolicyWithTimeStampSuffix,
+                               CustomNamePolicy)
+
+from pyspark import SparkConf, SparkContext
+from py4j.java_gateway import JavaObject
+
+
+@pytest.fixture(autouse=True)
+def with_spark_context():
+    os.environ['SPARK_CLASSPATH'] = ":".join(classpath_jars())
+    conf = (SparkConf()
+            .set("spark.driver.extraClassPath", os.environ['SPARK_CLASSPATH']))
+
+    if SparkContext._active_spark_context is None:
+        SparkContext(conf=conf)
+
+    yield SparkContext._active_spark_context
+
+    # TearDown
+    SparkContext.stop(SparkContext._active_spark_context)
+
+
+def test_CustomNamePolicyFactory():
+    java_obj = CustomNamePolicyFactory("jobName", "modelname", "epconfig", "ep")
+    assert(isinstance(java_obj._to_java(), JavaObject))
+
+
+def test_CustomNamePolicyWithTimeStampSuffixFactory():
+    java_obj = CustomNamePolicyWithTimeStampSuffixFactory("jobName", "modelname", "epconfig", "ep")
+    assert(isinstance(java_obj._to_java(), JavaObject))
+
+
+def test_CustomNamePolicyWithTimeStampSuffix():
+    java_obj = CustomNamePolicyWithTimeStampSuffix("jobName", "modelname", "epconfig", "ep")
+    assert(isinstance(java_obj._to_java(), JavaObject))
+
+
+def test_CustomNamePolicy():
+    java_obj = CustomNamePolicy("jobName", "modelname", "epconfig", "ep")
+    assert (isinstance(java_obj._to_java(), JavaObject))

--- a/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/NamePolicy.scala
+++ b/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/NamePolicy.scala
@@ -37,6 +37,46 @@ class RandomNamePolicyFactory(val prefix: String = "") extends NamePolicyFactory
 }
 
 /**
+  * Creates a [[CustomNamePolicy]] upon a call to [[CustomNamePolicyFactory#createNamePolicy]]
+  *
+  * @param trainingJobName The job name of the SageMaker entity with this NamePolicy
+  * @param modelName The model name of the SageMaker entity with this NamePolicy
+  * @param endpointConfigName The endpoint config name of the SageMaker entity with this NamePolicy
+  * @param endpointName The endpoint name of the SageMaker entity with this NamePolicy
+  */
+class CustomNamePolicyFactory(trainingJobName: String,
+                              modelName: String,
+                              endpointConfigName: String,
+                              endpointName: String) extends NamePolicyFactory {
+
+  override def createNamePolicy: NamePolicy = {
+    new CustomNamePolicy(trainingJobName, modelName, endpointConfigName, endpointName)
+  }
+
+}
+
+
+/**
+  * Creates a [[CustomNamePolicyWithTimeStampSuffixFactory]] upon a call to
+  * [[CustomNamePolicyWithTimeStampSuffix#createNamePolicy]]
+  *
+  * @param trainingJobName The job name of the SageMaker entity with this NamePolicy
+  * @param modelName The model name of the SageMaker entity with this NamePolicy
+  * @param endpointConfigName The endpoint config name of the SageMaker entity with this NamePolicy
+  * @param endpointName The endpoint name of the SageMaker entity with this NamePolicy
+  *
+  */
+class CustomNamePolicyWithTimeStampSuffixFactory(trainingJobName: String,
+                                                 modelName: String,
+                                                 endpointConfigName: String,
+                                                 endpointName: String) extends NamePolicyFactory {
+  override def createNamePolicy: NamePolicy = {
+    new CustomNamePolicyWithTimeStampSuffix(trainingJobName, modelName,
+                                            endpointConfigName, endpointName)
+  }
+}
+
+/**
   * Provides names for SageMaker entities created during fit in
   * [[com.amazonaws.services.sagemaker.sparksdk.SageMakerEstimator]]
   */
@@ -63,4 +103,40 @@ case class RandomNamePolicy(val prefix : String = "") extends NamePolicy {
   val modelName = s"${prefix}model-$uid-$timestamp"
   val endpointConfigName = s"${prefix}endpointConfig-$uid-$timestamp"
   val endpointName = s"${prefix}endpoint-$uid-$timestamp"
+}
+
+
+/**
+  * Provides user sepecified SageMaker entity names.
+  *
+  * @param trainingJobName The job name of the SageMaker entity with this NamePolicy
+  * @param modelName The model name of the SageMaker entity with this NamePolicy
+  * @param endpointConfigName The endpoint config name of the SageMaker entity with this NamePolicy
+  * @param endpointName The endpoint name of the SageMaker entity with this NamePolicy
+  */
+case class CustomNamePolicy(trainingJobName: String, modelName: String,
+                            endpointConfigName: String, endpointName: String) extends NamePolicy
+
+
+
+/**
+  * Provides user sepecified SageMaker entity names with a common timestamp suffix.
+  *
+  * @param _trainingJobName The job name of the SageMaker entity with this NamePolicy
+  * @param _modelName The model name of the SageMaker entity with this NamePolicy
+  * @param _endpointConfigName The endpoint config name of the SageMaker entity with this NamePolicy
+  * @param _endpointName The endpoint name of the SageMaker entity with this NamePolicy
+  */
+case class CustomNamePolicyWithTimeStampSuffix(private val _trainingJobName: String,
+                                               private val _modelName: String,
+                                               private val _endpointConfigName: String,
+                                               private val _endpointName: String
+                                              ) extends NamePolicy {
+  private val timestamp : String =
+    LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME).replace(":", "-").replace(".", "-")
+
+  val trainingJobName = s"${_trainingJobName}-$timestamp"
+  val modelName = s"${_modelName}-$timestamp"
+  val endpointConfigName = s"${_endpointConfigName}-$timestamp"
+  val endpointName = s"${_endpointName}-$timestamp"
 }

--- a/sagemaker-spark-sdk/src/test/scala/com/amazonaws/services/sagemaker/sparksdk/NamePolicyTests.scala
+++ b/sagemaker-spark-sdk/src/test/scala/com/amazonaws/services/sagemaker/sparksdk/NamePolicyTests.scala
@@ -46,4 +46,63 @@ class NamePolicyTests extends FlatSpec with Matchers with MockitoSugar {
     assert(policy.endpointConfigName.startsWith("prefix"))
     assert(policy.endpointName.startsWith("prefix"))
   }
+
+  "CustomNamePolicy" should "have custom names" in {
+    val policy = new CustomNamePolicy("jobName", "modelName", "endpointConfig", "endpointName")
+    assert(policy.trainingJobName.equals("jobName"))
+    assert(policy.modelName.equals("modelName"))
+    assert(policy.endpointConfigName.equals("endpointConfig"))
+    assert(policy.endpointName.startsWith("endpointName"))
+  }
+
+  "CustomNamePolicyWithTimeStampSuffix" should "have custom names with proper suffix" in {
+    val policy = new CustomNamePolicyWithTimeStampSuffix("jobName", "modelName",
+                                                              "endpointConfig", "endpointName")
+    assert(!policy.trainingJobName.equals("jobName"))
+    assert(!policy.modelName.equals("modelName"))
+    assert(!policy.endpointConfigName.equals("endpointConfig"))
+    assert(!policy.endpointName.equals("endpointName"))
+
+    assert(policy.trainingJobName.startsWith("jobName"))
+    assert(policy.modelName.startsWith("modelName"))
+    assert(policy.endpointConfigName.startsWith("endpointConfig"))
+    assert(policy.endpointName.startsWith("endpointName"))
+  }
+
+  "CustomNamePolicyFactory" should "return a custom name policy with correct params" in {
+    val jobName = "jobName"
+    val modelName = "modelName"
+    val endpointConfigName = "endpointConfigName"
+    val endpointName = "endpointName"
+    val factory = new CustomNamePolicyFactory(jobName, modelName, endpointConfigName, endpointName)
+    val policy = factory.createNamePolicy
+    assert(policy.isInstanceOf[CustomNamePolicy])
+    assert(policy.trainingJobName.equals(jobName))
+    assert(policy.modelName.equals(modelName))
+    assert(policy.endpointConfigName.equals(endpointConfigName))
+    assert(policy.endpointName.equals(endpointName))
+  }
+
+  "CustomNamePolicyWithTimeStampSuffixFactory" should
+    "return a custom name policy with timestamp suffix" in {
+    val jobName = "jobName"
+    val modelName = "modelName"
+    val endpointConfigName = "endpointConfigName"
+    val endpointName = "endpointName"
+    val factory = new CustomNamePolicyWithTimeStampSuffixFactory(jobName, modelName,
+                                                                  endpointConfigName, endpointName)
+    val policy = factory.createNamePolicy
+    assert(policy.isInstanceOf[CustomNamePolicyWithTimeStampSuffix])
+
+    assert(!policy.trainingJobName.equals(jobName))
+    assert(!policy.modelName.equals(modelName))
+    assert(!policy.endpointConfigName.equals(endpointConfigName))
+    assert(!policy.endpointName.equals(endpointName))
+
+    assert(policy.trainingJobName.startsWith(jobName))
+    assert(policy.modelName.startsWith(modelName))
+    assert(policy.endpointConfigName.startsWith(endpointConfigName))
+    assert(policy.endpointName.startsWith(endpointName))
+  }
+
 }


### PR DESCRIPTION
*Issue:*
Various name of SageMaker entities cannot be customized to the user needs only via the prefix.

*Description of changes:*
Make all entites of SageMaker namely jobName, modelName, endpointConfig and endpointName to be customized as per the user naming conventions. This also gives better control so that the names can be within the limit of 63 chars and as per the user needs

## Merge Checklist
- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-spark/blob/master/CONTRIBUTING.md) doc
- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-spark/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-spark/blob/master/README.md) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
