### PR TITLE
fix: freeze pyspark version to 2.3.2

### DIFF
--- a/sagemaker-pyspark-sdk/setup.py
+++ b/sagemaker-pyspark-sdk/setup.py
@@ -101,7 +101,7 @@ try:  # noqa
         scripts=["bin/sagemakerpyspark-jars", "bin/sagemakerpyspark-emr-jars"],
 
         install_requires=[
-            "pyspark>=2.3.2",
+            "pyspark==2.3.2",
             "numpy",
         ],
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Pyspark release after 2.4.0 have breaking changes. For now freeze pyspark to 2.3.2 to avoid those breaking changes and make sagemaker pyspark notebooks work.


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-spark/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-spark/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-spark/blob/master/README.md) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
