### PR TITLE
infra: correctly pipe credentials for Maven publish

### DIFF
--- a/sagemaker-spark-sdk/build.sbt
+++ b/sagemaker-spark-sdk/build.sbt
@@ -71,13 +71,20 @@ updateOptions := updateOptions.value.withGigahorse(false)
 publishMavenStyle := true
 pomIncludeRepository := { _ => false }
 publishArtifact in Test := false
+val nexusUriHost = "aws.oss.sonatype.org"
+val nexusUriHostWithScheme = "https://" + nexusUriHost + "/"
 publishTo := {
-  val nexus = "https://aws.oss.sonatype.org/"
   if (isSnapshot.value)
-    Some("snapshots" at nexus + "content/repositories/snapshots")
+    Some("snapshots" at nexusUriHostWithScheme + "content/repositories/snapshots")
   else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    Some("releases"  at nexusUriHostWithScheme + "service/local/staging/deploy/maven2")
 }
+credentials += Credentials(
+  "Sonatype Nexus Repository Manager",
+  nexusUriHost,
+  sys.env("SONATYPE_USERNAME"),
+  sys.env("SONATYPE_PASSWORD")
+)
 pomExtra := (
   <developers>
     <developer>

--- a/sagemaker-spark-sdk/build.sbt
+++ b/sagemaker-spark-sdk/build.sbt
@@ -82,8 +82,8 @@ publishTo := {
 credentials += Credentials(
   "Sonatype Nexus Repository Manager",
   nexusUriHost,
-  sys.env("SONATYPE_USERNAME"),
-  sys.env("SONATYPE_PASSWORD")
+  sys.env.getOrElse("SONATYPE_USERNAME", "NOT_A_PUBLISH_BUILD"),
+  sys.env.getOrElse("SONATYPE_PASSWORD", "NOT_A_PUBLISH_BUILD")
 )
 pomExtra := (
   <developers>


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Properly piping credentials in to be consumed during Maven publish.
I suspect the endpoint switch resulted in the default credential map key in the unofficial sbt-publish repo to no longer match the current set of variables, resulting in the credentials not being found.
This fix properly sets a credential map for the new endpoint.

*Testing:* I was able to get past the error, but am not able to run a full test because of a typo in one of my iterations that resulted in the 1.2.9 version being "reserved". The only way around this is to manually update the repo to version 1.2.10 and test a publish locally, OR push this and watch the magic happen. I picked option 2.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [X] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-spark/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have updated the [changelog](https://github.com/aws/sagemaker-spark/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [X] I have updated any necessary [documentation](https://github.com/aws/sagemaker-spark/blob/master/README.md) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
