### PR TITLE
fix: Update version of pyspark specified in install_requires

### DIFF
--- a/sagemaker-pyspark-sdk/setup.py
+++ b/sagemaker-pyspark-sdk/setup.py
@@ -101,7 +101,7 @@ try:  # noqa
         scripts=["bin/sagemakerpyspark-jars", "bin/sagemakerpyspark-emr-jars"],
 
         install_requires=[
-            "pyspark==2.3.4",
+            "pyspark==2.4.5",
             "numpy",
         ],
 


### PR DESCRIPTION
*Description of changes:*
https://github.com/aws/sagemaker-spark/pull/114 upgraded the version of pyspark in `setup_requires` but not in `install_requires`. This PR fixes that.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-spark/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-spark/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-spark/blob/master/README.md) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
