### PR TITLE
doc: remove EMR 5.19 as a compatible cluster version

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ SageMaker Spark is pre-installed on EMR releases since 5.11.0. You can run your 
 on EMR by submitting your Spark application jar and any additional dependencies your Spark application uses.
 
 SageMaker Spark applications have also been verified to be compatible with EMR-5.6.0 (which runs Spark 2.1) and EMR-5-8.0
-(which runs Spark 2.2) The latest compatible version is EMR-5.19.x (which runs Spark 2.3.2). When submitting your Spark application to an earlier EMR release, use the `--packages` flag to
+(which runs Spark 2.2). When submitting your Spark application to an earlier EMR release, use the `--packages` flag to
 depend on a recent version of the AWS Java SDK:  
 
 ```


### PR DESCRIPTION
*Issue #, if available:*
EMR 5.19 installs Spark 2.3.0, but sagemaker-spark is built as late as Spark 2.2.0.
And verified on EMR 5.19.0 cluster that ``sagemaker_pyspark`` was not installed correctly (e.g. ``CustomNamePolicy`` is missing from ``NamePolicy`` file)

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-spark/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-spark/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-spark/blob/master/README.md) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
