### PR TITLE
fix: Update xgboost image tag

### DIFF
--- a/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimator.scala
+++ b/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/algorithms/XGBoostSageMakerEstimator.scala
@@ -393,7 +393,7 @@ private[algorithms] trait XGBoostParams extends Params {
 
 object XGBoostSageMakerEstimator {
   val algorithmName = "xgboost"
-  val algorithmTag = "1"
+  val algorithmTag = "1.5-1"
   val regionAccountMap = SagerMakerRegionAccountMaps.ApplicationsAccountMap
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* xgboost image with tag `1` no longer supported, updating to `1.5-1` per https://docs.aws.amazon.com/sagemaker/latest/dg/ecr-us-east-2.html#xgboost-us-east-2.title

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-spark/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-spark/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-spark/blob/master/README.md) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
