### PR TITLE
fromEndpoint description

### DIFF
--- a/sagemaker-pyspark-sdk/src/sagemaker_pyspark/SageMakerModel.py
+++ b/sagemaker-pyspark-sdk/src/sagemaker_pyspark/SageMakerModel.py
@@ -227,7 +227,7 @@ class SageMakerModel(SageMakerJavaWrapper, JavaModel):
                      namePolicy=RandomNamePolicy(),
                      uid="sagemaker"):
 
-        """ Creates a JavaSageMakerModel from existing model data in S3.
+        """ Creates a JavaSageMakerModel from an existing model endpoint.
 
         The returned JavaSageMakerModel can be used to transform Dataframes.
 


### PR DESCRIPTION
Fix incorrect description for fromEndpoint.

*Issue #, if available:*

*Description of changes:* fromEndpoint had the same description as fromModelS3Path, referencing S3 which is incorrect.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [x ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-spark/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-spark/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-spark/blob/master/README.md) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
