### PR TITLE
fix: confine deleteTrainingData to the invoking job's own S3 objects

### DIFF
--- a/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/SageMakerEstimator.scala
+++ b/sagemaker-spark-sdk/src/main/scala/com/amazonaws/services/sagemaker/sparksdk/SageMakerEstimator.scala
@@ -462,14 +462,49 @@ class SageMakerEstimator(val trainingImage: String,
     val s3Prefix = s3DataPath.objectPath
 
     try {
+      // listObjects(bucket, prefix) matches any key that begins with the given string, without
+      // regard to '/' as a path-segment boundary. Because s3Prefix is the job's staging path with
+      // no trailing delimiter, the listing also returns objects belonging to *other* jobs whose
+      // names merely share this string prefix (e.g. "run1" vs "run10"). Deleting everything
+      // returned would destroy those unrelated jobs' data, so we filter the listing down to the
+      // objects that provably belong to this job before deleting.
       val objectList = s3Client.listObjects(s3Bucket, s3Prefix)
-      objectList.getObjectSummaries.forEach{
-        s3Object => s3Client.deleteObject(s3Bucket, s3Object.getKey)
+      objectList.getObjectSummaries.forEach { s3Object =>
+        val key = s3Object.getKey
+        if (belongsToTrainingJob(key, s3Prefix)) {
+          s3Client.deleteObject(s3Bucket, key)
+        } else {
+          log.warn(s"Skipping deletion of s3://$s3Bucket/$key: it shares the staging prefix " +
+            s"$s3Prefix but belongs to a different training job.")
+        }
       }
       s3Client.deleteObject(s3Bucket, s3Prefix)
     } catch {
       case t: Throwable => log.warn(s"Received exception from s3 client. Data deletion failed. " +
         s"Stack trace: ${t.getStackTrace}")
+    }
+  }
+
+  /**
+    * Determines whether an S3 object key produced by a prefix listing actually belongs to the
+    * training job staged at jobPrefix, as opposed to a different job whose name happens to share
+    * jobPrefix as a string prefix.
+    *
+    * SageMaker training job names are restricted to [a-zA-Z0-9-], so a sibling job that shares this
+    * string prefix always continues with a name character (alphanumeric or '-'). This job's own
+    * artifacts, by contrast, are always separated from jobPrefix by a non-name delimiter: '/' for
+    * staged data objects, '.' for the manifest file (jobPrefix + ".manifest.txt"), and '_' for
+    * Hadoop folder markers (jobPrefix + "_$folder$"). The prefix marker object itself is exactly
+    * jobPrefix.
+    */
+  private[sparksdk] def belongsToTrainingJob(key: String, jobPrefix: String): Boolean = {
+    if (key == jobPrefix) {
+      true
+    } else if (key.startsWith(jobPrefix) && key.length > jobPrefix.length) {
+      val delimiter = key.charAt(jobPrefix.length)
+      delimiter == '/' || delimiter == '.' || delimiter == '_'
+    } else {
+      false
     }
   }
 

--- a/sagemaker-spark-sdk/src/test/scala/com/amazonaws/services/sagemaker/sparksdk/SageMakerEstimatorTests.scala
+++ b/sagemaker-spark-sdk/src/test/scala/com/amazonaws/services/sagemaker/sparksdk/SageMakerEstimatorTests.scala
@@ -454,6 +454,58 @@ class SageMakerEstimatorTests extends FlatSpec with Matchers with MockitoSugar w
     verify(s3Mock, never).deleteObject(any[String], any[String])
   }
 
+  it should "not delete a sibling job's data whose name shares this job's staging prefix" in {
+    when(timeProviderMock.currentTimeMillis).thenReturn(0)
+    val mockAccount = "1234"
+    val mockResult = new GetCallerIdentityResult().withAccount(mockAccount)
+    when(stsMock.getCallerIdentity(any[GetCallerIdentityRequest])).thenReturn(mockResult)
+
+    // A listObjects(bucket, "b/test-training-job") call over-matches under S3's lexicographic
+    // prefix semantics: it returns this job's own object as well as a different job's object
+    // ("b/test-training-job-2/...") that merely shares the string prefix.
+    val ownObject = mock[S3ObjectSummary]
+    when(ownObject.getKey).thenReturn(s3DataPrefix)
+    val siblingKey = s3TrainingPrefix + "-2/data.pbr"
+    val siblingObject = mock[S3ObjectSummary]
+    when(siblingObject.getKey).thenReturn(siblingKey)
+    val objectListMock = mock[ObjectListing]
+    when(objectListMock.getObjectSummaries)
+      .thenReturn(util.Arrays.asList(ownObject, siblingObject))
+    when(s3Mock.listObjects(s3Bucket, s3TrainingPrefix)).thenReturn(objectListMock)
+
+    val estimator = new DummyEstimator()
+
+    when(sagemakerMock.describeTrainingJob(any[DescribeTrainingJobRequest]))
+      .thenReturn(statusToResult(TrainingJobStatus.InProgress))
+      .thenReturn(statusToResult(TrainingJobStatus.Completed))
+
+    estimator.fit(dataset)
+
+    // This job's own staged data and prefix marker are deleted...
+    verify(s3Mock).deleteObject(s3Bucket, s3DataPrefix)
+    verify(s3Mock).deleteObject(s3Bucket, s3TrainingPrefix)
+    // ...but the sibling job's data is left untouched.
+    verify(s3Mock, never).deleteObject(s3Bucket, siblingKey)
+  }
+
+  it should "delete only this job's own artifacts across supported delimiters" in {
+    val estimator = new DummyEstimator()
+    val jobPrefix = "shared/run1"
+
+    // Objects that belong to this job: the prefix marker, staged data under it, the EMR manifest
+    // sibling, and the Hadoop folder marker.
+    assert(estimator.belongsToTrainingJob("shared/run1", jobPrefix))
+    assert(estimator.belongsToTrainingJob("shared/run1/part-00000.snappy.parquet", jobPrefix))
+    assert(estimator.belongsToTrainingJob("shared/run1.manifest.txt", jobPrefix))
+    assert(estimator.belongsToTrainingJob("shared/run1_$folder$", jobPrefix))
+
+    // Objects that belong to a different job sharing the string prefix must not be matched.
+    assert(!estimator.belongsToTrainingJob("shared/run10/part-00000.snappy.parquet", jobPrefix))
+    assert(!estimator.belongsToTrainingJob("shared/run1000", jobPrefix))
+    assert(!estimator.belongsToTrainingJob("shared/run1-extra/data.pbr", jobPrefix))
+    assert(!estimator.belongsToTrainingJob("shared/other/data.pbr", jobPrefix))
+  }
+
   val dummyModelArtifactLocation : String = "s3://bucket/string"
 
   case class DummyNamePolicy(val prefix : String = "") extends NamePolicy {


### PR DESCRIPTION
  SageMakerEstimator.deleteTrainingData listed staging objects via
  listObjects(bucket, prefix) with no trailing delimiter and deleted every
  returned key. Because S3 prefix matching is purely lexicographic, a job
  whose name is a string prefix of another (e.g. run1 vs run10) would,
  during its own end-of-training cleanup, also delete the sibling job's
  data under a shared staging prefix.

  Keep the listing as-is (it must over-match to find the manifest and
  $ markers that live as siblings of the prefix) but filter deletion
  to keys that provably belong to this job. SageMaker job names are
  restricted to [a-zA-Z0-9-], so a job's own artifacts are always separated
  from the prefix by a non-name delimiter ('/' for staged data, '.' for
  .manifest.txt, '_' for _$), while a sibling sharing the string
  prefix always continues with a name character. This makes the separation
  exact: no sibling key can pass the filter, and no owned key is skipped.

  Add tests covering the sibling-collision case at fit() level and the
  belongsToTrainingJob discriminator across all owned-artifact delimiters.

*Issue #, if available:*

*Description of changes:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-spark/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have updated the [changelog](https://github.com/aws/sagemaker-spark/blob/master/CHANGELOG.rst) with a description of my changes (if appropriate)
- [ ] I have updated any necessary [documentation](https://github.com/aws/sagemaker-spark/blob/master/README.md) (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
